### PR TITLE
Extend Figma node types to allow for more powerful data manipulation

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,9 +89,11 @@ query ImageQuery {
 
 ### Projects
 
-Make sure that `projectId` and `accessToken` are set inside `gatsby-config.js`.
+Make sure that `projectId` and `accessToken` are set inside `gatsby-config.js`. Using this method, you can now query `components`, `frames`, `instances`, and more via `graphql` filters. 
 
-```graphql
+```
+// All Figma Documents
+
 query ProjectQuery {
   allFigmaDocument {
     edges {
@@ -100,6 +102,38 @@ query ProjectQuery {
         pages {
           name
         }
+      }
+    }
+  }
+}
+```
+
+```
+// Specific Figma Component
+
+query ProjectComponentQuery {
+  figmaComponent(name: {eq: "MyComponent"}) {
+    instances {
+      name
+      rectangles {
+        name
+      }
+      texts {
+        name
+      }
+    }
+  }
+}
+```
+
+```
+// Figma Frames that start with "Button"
+
+query ProjectFrameQuery {
+  allFigmaFrame(filter: {name: {regex: "/Button/"}}) {
+    edges {
+      node {
+        name
       }
     }
   }

--- a/src/gatsby-node.js
+++ b/src/gatsby-node.js
@@ -19,7 +19,74 @@ See docs here – https://github.com/fabe/gatsby-source-figma
     `);
   }
 
-  const { createNode } = actions;
+  const { createNode, createTypes } = actions;
+
+  const typeDefs = `
+    type FigmaCOMPONENT implements Node {
+      ellipses: [FigmaELLIPSE!]
+      frames: [FigmaFRAME!]
+      groups: [FigmaGROUP!]
+      instances: [FigmaINSTANCE!]
+      lines: [FigmaLINE!]
+      rectangles: [FigmaRECTANGLE!]
+      texts: [FigmaTEXT!]
+      vectors: [FigmaVECTOR!]
+    }
+
+    type FigmaFRAME implements Node {
+      components: [FigmaCOMPONENT!]
+      ellipses: [FigmaELLIPSE!]
+      frames: [FigmaFRAME!]
+      groups: [FigmaGROUP!]
+      instances: [FigmaINSTANCE!]
+      lines: [FigmaLINE!]
+      rectangles: [FigmaRECTANGLE!]
+      texts: [FigmaTEXT!]
+      vectors: [FigmaVECTOR!]
+    }
+
+    type FigmaGROUP implements Node {
+      components: [FigmaCOMPONENT!]
+      ellipses: [FigmaELLIPSE!]
+      frames: [FigmaFRAME!]
+      groups: [FigmaGROUP!]
+      instances: [FigmaINSTANCE!]
+      lines: [FigmaLINE!]
+      rectangles: [FigmaRECTANGLE!]
+      texts: [FigmaTEXT!]
+      vectors: [FigmaVECTOR!]
+    }
+
+    type FigmaINSTANCE implements Node {
+      ellipses: [FigmaELLIPSE!]
+      frames: [FigmaFRAME!]
+      groups: [FigmaGROUP!]
+      instances: [FigmaINSTANCE!]
+      lines: [FigmaLINE!]
+      rectangles: [FigmaRECTANGLE!]
+      texts: [FigmaTEXT!]
+      vectors: [FigmaVECTOR!]
+    }
+
+    type FigmaPAGE implements Node {
+      components: [FigmaCOMPONENT!]
+      ellipses: [FigmaELLIPSE!]
+      frames: [FigmaFRAME!]
+      groups: [FigmaGROUP!]
+      instances: [FigmaINSTANCE!]
+      lines: [FigmaLINE!]
+      rectangles: [FigmaRECTANGLE!]
+      texts: [FigmaTEXT!]
+      vectors: [FigmaVECTOR!]
+    }
+
+    type FigmaDOCUMENT implements Node {
+      pages: [FigmaPAGE!]
+    }
+  `;
+
+  createTypes(typeDefs)
+
   let files = [];
   let images = [];
   let project = {};
@@ -27,7 +94,7 @@ See docs here – https://github.com/fabe/gatsby-source-figma
   if (fileId) {
 
     const file = await Figma.fetchFile(fileId, accessToken);
-    
+
     files = [file];
   } else if (projectId) {
     project = await Figma.fetchProject(projectId, accessToken);
@@ -47,27 +114,90 @@ See docs here – https://github.com/fabe/gatsby-source-figma
     images = await Promise.all(imagesData);
   }
 
-  const createDocument = file => {
+  const createDocumentNodes = async (node, parentNode) => {
+    const { children } = node;
 
-    return Object.assign(file.document, {
-      id: file.id,
-      figmaId: file.id,
-      name: file.name,
-      thumbnailUrl: file.thumbnailUrl,
-      lastModified: file.lastModified,
-      parent: null,
+    // Figma uses Canvas and Page interchangeably
+    // We already use the "Page" convention, so let's stick with it
+    const formattedType = (node.type === 'CANVAS') ? 'PAGE' : node.type;
+
+    const initializeFigmaProperties = () => {
+      // Here, we want to include the parent File properties on our Documents
+      // and make sure to include empty array to initialize with page nodes
+      if (node.type === 'DOCUMENT') {
+        return {
+          lastModified: parentNode.lastModified,
+          pages: [],
+          thumbnailUrl: parentNode.thumbnailUrl,
+          version: parentNode.version,
+        };
+      }
+
+      // Initialize empty arrays for nested Figma nodes inside of component/instance nodes
+      // NOTE: Figma does not allow components/instances to contain nested components
+      if (node.type === 'COMPONENT' || node.type === 'INSTANCE') {
+        return {
+          ellipses: [],
+          frames: [],
+          groups: [],
+          instances: [],
+          rectangles: [],
+          texts: [],
+          vectors: [],
+        };
+      }
+
+      // Initialize empty arrays for nested Figma nodes inside frame, group, & page nodes
+      if (node.type === 'FRAME' || node.type === 'GROUP' || node.type === 'PAGE') {
+        return {
+          components: [],
+          ellipses: [],
+          frames: [],
+          groups: [],
+          instances: [],
+          rectangles: [],
+          texts: [],
+          vectors: [],
+        };
+      }
+
+      return {};
+    };
+
+    const nodeObject = Object.assign(node, {
+      id: node.id,
+      figmaId: node.id,
+      name: node.name,
+      parent: parentNode.id,
       children: [],
-      pages: file.document.children,
       internal: {
-        type: `Figma${file.document.type}`,
-        contentDigest: createContentDigest(JSON.stringify(file)),
+        type: `Figma${formattedType}`,
+        contentDigest: createContentDigest(JSON.stringify(node)),
       },
-      document___NODE: file.id,
-    });
+      // document___NODE: file.id,
+    }, initializeFigmaProperties());
+
+    if (children !== undefined) {
+      await children.forEach((childNode) => {
+        // Figma uses Canvas and Page interchangeably
+        // We already use the "Page" convention, so let's stick with it
+        const formattedPropName = (childNode.type === 'CANVAS')
+          ? 'pages' : `${childNode.type.toLowerCase()}s`;
+
+        if (nodeObject[formattedPropName] === undefined) {
+          nodeObject[formattedPropName] = [];
+        }
+
+        nodeObject[formattedPropName].push(childNode);
+        createDocumentNodes(childNode, nodeObject);
+      });
+    }
+
+    createNode(nodeObject);
   };
 
   const createImage = image => {
-    
+
     // figma returns images with encoded IDs, so we have to decode
     const imageSrc = image.images[Object.keys(image.images)[0]];
 
@@ -84,7 +214,7 @@ See docs here – https://github.com/fabe/gatsby-source-figma
     });
   }
 
-  files.forEach(file => createNode(createDocument(file)));
+  files.forEach(file => createDocumentNodes(file.document, file));
   images.forEach(image => createNode(createImage(image)));
 
   return;


### PR DESCRIPTION
Summary of changes:
- Added type defs and node object properties to prevent queried data from returning null values.
- Renamed `createDocument()` to `createDocumentNodes()` to better reflect the new functionality of populating parent node automatically and recursively creating nodes from any existing children elements.


Hey there @fabe 👋

I started using this lovely repository on one of my side projects and noticed [this issue](https://github.com/fabe/gatsby-source-figma/issues/1). This became a pretty big thorn for me when I started working with my designer, trying to access the properties of a deeply nested node. The gist of this commit is the addition of a recursive loop that creates nodes from the `children` property of each Figma object. This means that developers no longer have to search through nested nodes and instead can now query against all of Figma's various node types!

Let me know if there is anything else you need from me while you consider this PR. Thanks again for taking a look and putting in the work to make this plugin exist in the first place!